### PR TITLE
Add multilingual Flask app with testing support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        
+    - name: Run tests
+      run: |
+        python tests.py

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 /.env.production
+/assets

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/app.py
+++ b/app.py
@@ -1,10 +1,35 @@
-from flask import Flask
+from flask import Flask, render_template, send_from_directory, request, session, redirect, url_for
+from flask_babel import Babel, gettext as _
+import os
 
 app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'development-key-change-in-production')
+app.config['BABEL_DEFAULT_LOCALE'] = 'es'
+app.config['BABEL_TRANSLATION_DIRECTORIES'] = 'translations'
+
+babel = Babel(app)
+
+@babel.localeselector
+def get_locale():
+    # Primero intenta obtener el idioma de la sesión
+    if 'language' in session:
+        return session['language']
+    # Si no hay idioma en la sesión, usa el del navegador
+    return request.accept_languages.best_match(['es', 'en'])
 
 @app.route('/')
 def home():
-    return "¡Hola Mundo desde UpdateMe!"
+    return render_template('index.html', title=_("title_homepage"))
+
+@app.route('/static/<path:path>')
+def serve_static(path):
+    return send_from_directory('static', path)
+
+@app.route('/change_language/<language>')
+def change_language(language):
+    session['language'] = language
+    return redirect(request.referrer or url_for('home'))
 
 if __name__ == '__main__':
+    os.system('pybabel compile -d translations')
     app.run(debug=True)

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,3 @@
+[python: **.py]
+[jinja2: **/templates/**.html]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 Flask==2.3.3
 Werkzeug==2.3.7
 gunicorn==21.2.0
+bcrypt==4.0.1
 python-dotenv==1.1.0
+Flask-Babel==2.0.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="{{ g.locale }}">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+    <!-- Incluir Tailwind CSS desde CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Configuración de Tailwind -->
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        primary: '#3B82F6',    // Azul principal
+                        secondary: '#10B981',  // Verde para acciones secundarias
+                        dark: '#1F2937',       // Color oscuro para fondos
+                        light: '#F9FAFB',      // Color claro para fondos
+                        accent: '#8B5CF6',     // Color de acento para destacados
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', 'sans-serif'],
+                    },
+                    spacing: {
+                        '128': '32rem',
+                    },
+                    borderRadius: {
+                        'xl': '1rem',
+                        '2xl': '2rem',
+                    }
+                }
+            }
+        }
+    </script>
+</head>
+
+<body class="bg-gray-50 min-h-screen flex items-center justify-center">
+    <div class="text-center px-4">
+        <div class="text-6xl md:text-8xl mb-6">
+            🚧 👷‍♂️ 🏗️
+        </div>
+        <h1 class="text-3xl md:text-4xl font-bold text-gray-800 mb-4">
+            {{ _('This page is under construction') }}
+        </h1>
+        <p class="text-xl text-gray-600 max-w-lg mx-auto">
+            {{ _('We\'re working to provide you with a better experience. Check back soon for our updates!') }}
+        </p>
+        <div class="mt-10">
+            <div class="inline-block h-1 w-32 bg-primary"></div>
+        </div>
+        <p class="mt-8 text-gray-500">
+            &copy; 2025 UpdateMe
+        </p>
+    </div>
+</body>
+
+</html>

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,13 @@
+import unittest
+import sys
+
+# Descubre y ejecuta todas las pruebas en el directorio tests/
+loader = unittest.TestLoader()
+start_dir = 'tests'
+suite = loader.discover(start_dir)
+
+runner = unittest.TextTestRunner()
+result = runner.run(suite)
+
+# Salir con código de error si alguna prueba falló
+sys.exit(not result.wasSuccessful())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import unittest
+from app import app
+
+class TestBase(unittest.TestCase):
+    """Clase base para todas las pruebas de la aplicación Flask."""
+    
+    def setUp(self):
+        """Configurar para cada prueba."""
+        self.app = app
+        self.app.config.update({
+            "TESTING": True,
+            "WTF_CSRF_ENABLED": False  # Desactiva CSRF para pruebas (cuando implementes formularios)
+        })
+        self.client = self.app.test_client()
+        self.runner = self.app.test_cli_runner()
+        
+    def tearDown(self):
+        """Limpiar después de cada prueba."""
+        pass  # Puedes añadir limpieza si es necesario

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,18 @@
+import unittest
+from conftest import TestBase
+
+class TestRoutes(TestBase):
+    """Pruebas para las rutas principales de la aplicación."""
+    
+    def test_home_page(self):
+        """
+        GIVEN la aplicación configurada para pruebas
+        WHEN se solicita la página principal '/'
+        THEN se debe recibir una respuesta 200 OK y verificar el contenido
+        """
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'UpdateMe', response.data)  # Verifica que el nombre de la app aparece en la página
+
+if __name__ == '__main__':
+    unittest.main()

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -1,0 +1,22 @@
+# Traducciones al inglés para UpdateMe
+msgid ""
+msgstr ""
+"Project-Id-Version: UpdateMe 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-14 15:30+0000\n"
+"PO-Revision-Date: 2025-04-14 15:30+0000\n"
+"Last-Translator: UpdateMe Team <info@updateme.com>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "title_homepage"
+msgstr "Landing Page - UpdateMe"
+
+msgid "This page is under construction"
+msgstr "This page is under construction"
+
+msgid "We're working to provide you with a better experience. Check back soon for our updates!"
+msgstr "We're working to provide you with a better experience. Check back soon for our updates!"

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1,0 +1,22 @@
+# Traducciones al español para UpdateMe
+msgid ""
+msgstr ""
+"Project-Id-Version: UpdateMe 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-14 15:30+0000\n"
+"PO-Revision-Date: 2025-04-14 15:30+0000\n"
+"Last-Translator: UpdateMe Team <info@updateme.com>\n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "title_homepage"
+msgstr "Landing Page - UpdateMe"
+
+msgid "This page is under construction"
+msgstr "Esta página está en modo construcción"
+
+msgid "We're working to provide you with a better experience. Check back soon for our updates!"
+msgstr "Estamos trabajando para ofrecerte una mejor experiencia. ¡Vuelve pronto para ver nuestras novedades!"


### PR DESCRIPTION
Introduce a Flask application with multilingual capabilities in English and Spanish, along with an initial HTML template. Implement a testing framework and GitHub Actions workflow for automated testing. Update .gitignore to exclude sensitive files.